### PR TITLE
Release `v0.4.0.post1`

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -9,6 +9,7 @@ leaderboard
 OpenAPI
 v0.1.0
 0.2.0.post1
+0.4.0.post1
 AEAs
 Tendermint
 mempool

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Release History - `Contribution Service`
 
+## 0.4.0.post1 (2023-04-03)
+
+- Bump to `open-autonomy@v0.10.0.post2`
+- Sets the `p2p_libp2p_client` as none abstract to enable `ACN`
+
 ## 0.4.0 (2023-03-27)
 
 - Bump to `open-autonomy@v0.10.0.post1`

--- a/Pipfile
+++ b/Pipfile
@@ -28,8 +28,8 @@ open-aea = "==1.31.0"
 open-aea-ledger-ethereum = "==1.31.0"
 open-aea-ledger-cosmos = "==1.31.0"
 open-aea-cli-ipfs = "==1.31.0"
-open-aea-test-autonomy = "==0.10.0.post1"
-open-autonomy = {version = "==0.10.0.post1", extras = [ "all"]}
+open-aea-test-autonomy = "==0.10.0.post2"
+open-autonomy = {version = "==0.10.0.post2", extras = [ "all"]}
 Pillow = "==9.2.0"
 tomte = {version = "==0.2.4", extras = ["tox", "tests"]}
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `contribution-service` are currently
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| `v0.4.0`    | :white_check_mark: |
-| `< v0.4.0`  | :x:                |
+| `v0.4.0.post1`    | :white_check_mark: |
+| `< v0.4.0.post1`  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ In order to run a local demo of the Autonolas Contribute service:
 2. Fetch the Autonolas Contribute service.
 
 	```bash
-	autonomy fetch valory/contribution:0.1.0:bafybeigna5nwpgaegnk775agd4tf6u3upkh6ocalthm2sb7hch4tkyqeo4 --service
+	autonomy fetch valory/contribution:0.1.0:bafybeigec7ged7r6mkywu5ddg3lutkneiinahcfl3hi5iui6tfbt6emas4 --service
 	```
 
 3. Build the Docker image of the service agents

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,14 +20,14 @@ In order to run a local demo of the Autonolas Contribute service:
     mkdir your_workspace && cd your_workspace
     touch Pipfile && pipenv --python 3.10 && pipenv shell
 
-    pipenv install open-autonomy[all]==0.10.0.post1
+    pipenv install open-autonomy[all]==0.10.0.post2
     autonomy init --remote --ipfs --reset --author=your_name
     ```
 
 2. Fetch the Autonolas Contribute service.
 
 	```bash
-	autonomy fetch valory/contribution:0.1.0:bafybeih3b5az26h7rm3ogb7cltrspj5i66zlllni3nqfpb6yz32esd4lhu --service
+	autonomy fetch valory/contribution:0.1.0:bafybeigna5nwpgaegnk775agd4tf6u3upkh6ocalthm2sb7hch4tkyqeo4 --service
 	```
 
 3. Build the Docker image of the service agents

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -3,8 +3,8 @@
         "contract/valory/dynamic_contribution/0.1.0": "bafybeicm7walyd343vuazxc7lkyxnfjryemigrw7qgk66hsb7qvve3ck6m",
         "skill/valory/dynamic_nft_abci/0.1.0": "bafybeifo5gbu36ujrzap2b3iaejne2pewnjhxb4sdddumhjjagptkdnq4a",
         "skill/valory/contribution_abci/0.1.0": "bafybeigwctmbv2pkh3fphd4myjpb2nyz5cxzjd44cuemgqr56e2qspglzq",
-        "agent/valory/contribution/0.1.0": "bafybeic3ms5saaxsiairqzscfqg2z7podxdvteftostpmbpgl4udyfcqqm",
-        "service/valory/contribution/0.1.0": "bafybeigna5nwpgaegnk775agd4tf6u3upkh6ocalthm2sb7hch4tkyqeo4"
+        "agent/valory/contribution/0.1.0": "bafybeica3q5tg6xj3ifbfoe4wtoifufcrlu2q6j3mb3ta5osrhmsawmvpi",
+        "service/valory/contribution/0.1.0": "bafybeigec7ged7r6mkywu5ddg3lutkneiinahcfl3hi5iui6tfbt6emas4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeibqlfmikg5hk4phzak6gqzhpkt6akckx7xppbp53mvwt6r73h7tk4",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/dynamic_contribution/0.1.0": "bafybeicm7walyd343vuazxc7lkyxnfjryemigrw7qgk66hsb7qvve3ck6m",
-        "skill/valory/dynamic_nft_abci/0.1.0": "bafybeicvazrmiuf5k6n34hsif2esnm5c7m3afjzysprsa7jqxtfpwwf5vy",
-        "skill/valory/contribution_abci/0.1.0": "bafybeiboyujpkwlwqxvnljk5efbzgzpmumy4qatpfkimp2zzxp2u7ug5ye",
-        "agent/valory/contribution/0.1.0": "bafybeiagorrzru2lugbn2n7rzb5ezrrln2iacosr3afkxbokg4dmbs2hqm",
-        "service/valory/contribution/0.1.0": "bafybeih3b5az26h7rm3ogb7cltrspj5i66zlllni3nqfpb6yz32esd4lhu"
+        "skill/valory/dynamic_nft_abci/0.1.0": "bafybeifo5gbu36ujrzap2b3iaejne2pewnjhxb4sdddumhjjagptkdnq4a",
+        "skill/valory/contribution_abci/0.1.0": "bafybeigwctmbv2pkh3fphd4myjpb2nyz5cxzjd44cuemgqr56e2qspglzq",
+        "agent/valory/contribution/0.1.0": "bafybeic3ms5saaxsiairqzscfqg2z7podxdvteftostpmbpgl4udyfcqqm",
+        "service/valory/contribution/0.1.0": "bafybeigna5nwpgaegnk775agd4tf6u3upkh6ocalthm2sb7hch4tkyqeo4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeibqlfmikg5hk4phzak6gqzhpkt6akckx7xppbp53mvwt6r73h7tk4",
@@ -15,12 +15,12 @@
         "protocol/valory/acn/1.1.0": "bafybeignmc5uh3vgpuckljcj2tgg7hdqyytkm6m5b6v6mxtazdcvubibva",
         "protocol/valory/ipfs/0.1.0": "bafybeihlgai5pbmkb6mjhvgy4gkql5uvpwvxbpdowczgz4ovxat6vajrq4",
         "protocol/valory/tendermint/0.1.0": "bafybeicusvezoqlmyt6iqomcbwaz3xkhk2qf3d56q5zprmj3xdxfy64k54",
-        "skill/valory/abstract_abci/0.1.0": "bafybeigg5ofide2gxwgjvljjgpyy6ombby7ph6pg7erj3h6itduwpn6pqu",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeidtb4v44zbxx7uw2c5yrbmmvzuh4mkgvcqdfyf4eq2xuhvxnbfiru",
-        "skill/valory/registration_abci/0.1.0": "bafybeid7gh35wnotm27hwuuuv3oozu33izjfafy7vbyzejdy3scx4oc7cu",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeicn5utwviq46ubguok5rl5go4hb7oxluj7t6bja2ut4epjw2hevei",
-        "contract/valory/service_registry/0.1.0": "bafybeigvob5pgz527goh2cgibjejnmbu6xz2e3knjsocjq533m3xe5uzti",
-        "connection/valory/abci/0.1.0": "bafybeienpqzsym3rg7nnomd6mxgbt4didwd4wfj72oadde27trdmcgsu5y",
+        "skill/valory/abstract_abci/0.1.0": "bafybeiebo5lfk7htzdarpfixqt4zedf7t6a57k6rejw7xqletcxbclmf4y",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeigorzha2vv47yooay4tscn7qdu57e6lgudbacyiktnobmaw34j2pe",
+        "skill/valory/registration_abci/0.1.0": "bafybeicu26bx4er4z7d5ca6pxkagqu6u2zxajyzlknigde6sep4mblhq7q",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeiacsn3k7q5ytxg52enceluqgp3xbzb4raks5vlkvmeikqje4fkes4",
+        "contract/valory/service_registry/0.1.0": "bafybeidiqury24wf7byjso5u4f7n4soa5xgcbo4iksegx3cvpa3bxlqm74",
+        "connection/valory/abci/0.1.0": "bafybeib4ogh45setwh5ved653knyp7cvnafn54dkfaxmgufmypzbp6bvwy",
         "connection/valory/http_client/0.23.0": "bafybeidykl4elwbcjkqn32wt5h4h7tlpeqovrcq3c5bcplt6nhpznhgczi",
         "connection/valory/ipfs/0.1.0": "bafybeie46fu7mv64q72dwzoxg77zbiv3pzsigzjk3rehjpm47cf3y77mha",
         "connection/valory/ledger/0.19.0": "bafybeighon6i2qfl2xrg7t3lbdzlkyo4v2a7ayvwso7m5w7pf2hvjfs2ma",

--- a/packages/valory/agents/contribution/aea-config.yaml
+++ b/packages/valory/agents/contribution/aea-config.yaml
@@ -146,13 +146,13 @@ models:
       max_healthcheck: 120
       max_attempts: 10
       reset_pause_duration: ${int:300}
-      on_chain_service_id: null
+      on_chain_service_id: ${int:null}
       reset_tendermint_after: 2
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 30.0
       service_id: contribution_service
-      service_registry_address: null
+      service_registry_address: ${str:null}
       setup:
         all_participants: ${list:[]}
         safe_contract_address: ${str:0x0000000000000000000000000000000000000000}

--- a/packages/valory/agents/contribution/aea-config.yaml
+++ b/packages/valory/agents/contribution/aea-config.yaml
@@ -16,7 +16,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - fetchai/http_server:0.22.0:bafybeihaax5od5zo5jk2l62hv4jwuwtxloh5mijozudpsjombqc4ncmi6i
-- valory/abci:0.1.0:bafybeienpqzsym3rg7nnomd6mxgbt4didwd4wfj72oadde27trdmcgsu5y
+- valory/abci:0.1.0:bafybeib4ogh45setwh5ved653knyp7cvnafn54dkfaxmgufmypzbp6bvwy
 - valory/http_client:0.23.0:bafybeidykl4elwbcjkqn32wt5h4h7tlpeqovrcq3c5bcplt6nhpznhgczi
 - valory/ledger:0.19.0:bafybeighon6i2qfl2xrg7t3lbdzlkyo4v2a7ayvwso7m5w7pf2hvjfs2ma
 - valory/p2p_libp2p_client:0.1.0:bafybeidwcobzb7ut3efegoedad7jfckvt2n6prcmd4g7xnkm6hp6aafrva
@@ -27,12 +27,12 @@ protocols:
 - valory/contract_api:1.0.0:bafybeidv6wxpjyb2sdyibnmmum45et4zcla6tl63bnol6ztyoqvpl4spmy
 - valory/http:1.0.0:bafybeifyoio7nlh5zzyn5yz7krkou56l22to3cwg7gw5v5o3vxwklibhty
 skills:
-- valory/abstract_abci:0.1.0:bafybeigg5ofide2gxwgjvljjgpyy6ombby7ph6pg7erj3h6itduwpn6pqu
-- valory/abstract_round_abci:0.1.0:bafybeicn5utwviq46ubguok5rl5go4hb7oxluj7t6bja2ut4epjw2hevei
-- valory/contribution_abci:0.1.0:bafybeiboyujpkwlwqxvnljk5efbzgzpmumy4qatpfkimp2zzxp2u7ug5ye
-- valory/dynamic_nft_abci:0.1.0:bafybeicvazrmiuf5k6n34hsif2esnm5c7m3afjzysprsa7jqxtfpwwf5vy
-- valory/registration_abci:0.1.0:bafybeid7gh35wnotm27hwuuuv3oozu33izjfafy7vbyzejdy3scx4oc7cu
-- valory/reset_pause_abci:0.1.0:bafybeidtb4v44zbxx7uw2c5yrbmmvzuh4mkgvcqdfyf4eq2xuhvxnbfiru
+- valory/abstract_abci:0.1.0:bafybeiebo5lfk7htzdarpfixqt4zedf7t6a57k6rejw7xqletcxbclmf4y
+- valory/abstract_round_abci:0.1.0:bafybeiacsn3k7q5ytxg52enceluqgp3xbzb4raks5vlkvmeikqje4fkes4
+- valory/contribution_abci:0.1.0:bafybeigwctmbv2pkh3fphd4myjpb2nyz5cxzjd44cuemgqr56e2qspglzq
+- valory/dynamic_nft_abci:0.1.0:bafybeifo5gbu36ujrzap2b3iaejne2pewnjhxb4sdddumhjjagptkdnq4a
+- valory/registration_abci:0.1.0:bafybeicu26bx4er4z7d5ca6pxkagqu6u2zxajyzlknigde6sep4mblhq7q
+- valory/reset_pause_abci:0.1.0:bafybeigorzha2vv47yooay4tscn7qdu57e6lgudbacyiktnobmaw34j2pe
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -101,7 +101,6 @@ cert_requests:
   not_before: '2022-01-01'
   public_key: ${str:02d3a830c9d6ea1ae91936951430dee11f4662f33118b02190693be835359a9d77}
   save_path: .certs/acn_cosmos_11000.txt
-is_abstract: true
 ---
 public_id: valory/contribution_abci:0.1.0
 type: skill

--- a/packages/valory/services/contribution/service.yaml
+++ b/packages/valory/services/contribution/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaeysyipptsieavfpyfkrfl3n37klu3ux7o2rtks2w4k2nnr2hshu
 fingerprint_ignore_patterns: []
-agent: valory/contribution:0.1.0:bafybeiagorrzru2lugbn2n7rzb5ezrrln2iacosr3afkxbokg4dmbs2hqm
+agent: valory/contribution:0.1.0:bafybeic3ms5saaxsiairqzscfqg2z7podxdvteftostpmbpgl4udyfcqqm
 number_of_agents: 4
 deployment: {}
 ---
@@ -34,8 +34,8 @@ models:
       reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
       share_tm_config_on_startup: ${USE_ACN:bool:false}
       token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
-      service_registry_address: null
-      on_chain_service_id: null
+      service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
+      on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
       setup:
         all_participants: ${ALL_PARTICIPANTS:list:[]}
         safe_contract_address: '0x0000000000000000000000000000000000000000'

--- a/packages/valory/services/contribution/service.yaml
+++ b/packages/valory/services/contribution/service.yaml
@@ -8,38 +8,132 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaeysyipptsieavfpyfkrfl3n37klu3ux7o2rtks2w4k2nnr2hshu
 fingerprint_ignore_patterns: []
-agent: valory/contribution:0.1.0:bafybeic3ms5saaxsiairqzscfqg2z7podxdvteftostpmbpgl4udyfcqqm
+agent: valory/contribution:0.1.0:bafybeica3q5tg6xj3ifbfoe4wtoifufcrlu2q6j3mb3ta5osrhmsawmvpi
 number_of_agents: 4
 deployment: {}
 ---
 public_id: valory/contribution_abci:0.1.0
 type: skill
-models:
-  benchmark_tool:
-    args:
-      log_dir: /logs
-  params:
-    args:
-      broadcast_to_server: false
-      dynamic_contribution_contract_address: ${DYNAMIC_CONTRIBUTION_CONTRACT_ADDRESS:str:0x5FbDB2315678afecb367f032d93F642f64180aa3}
-      earliest_block_to_monitor: ${EARLIEST_BLOCK_TO_MONITOR:int:8053690}
-      history_end: null
-      ipfs_domain_name: /dns/registry.autonolas.tech/tcp/443/https
-      ipfs_gateway_base_url: ${IPFS_GATEWAY_BASE_URL:str:https://gateway.staging.autonolas.tech/ipfs/}
-      leaderboard_api_key: ${LEADERBOARD_API_KEY:str:<leaderboard_api_key>}
-      leaderboard_base_endpoint: ${LEADERBOARD_BASE_ENDPOINT:str:https://sheets.googleapis.com/v4/spreadsheets}
-      leaderboard_layers_range: ${LEADERBOARD_LAYERS_RANGE:str:Layers!B1:Z3}
-      leaderboard_points_range: ${LEADERBOARD_POINTS_RANGE:str:Ranking!B2:C302}
-      leaderboard_sheet_id: ${LEADERBOARD_SHEET_ID:str:1m7jUYBoK4bFF0F2ZRnT60wUCAMWGMJ_ZfALsLfW5Dxc}
-      reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
-      share_tm_config_on_startup: ${USE_ACN:bool:false}
-      token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
-      service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
-      on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
-      setup:
-        all_participants: ${ALL_PARTICIPANTS:list:[]}
-        safe_contract_address: '0x0000000000000000000000000000000000000000'
-        consensus_threshold: null
+0:
+  models:
+    benchmark_tool:
+      args:
+        log_dir: /logs
+    params:
+      args:
+        broadcast_to_server: false
+        dynamic_contribution_contract_address: ${DYNAMIC_CONTRIBUTION_CONTRACT_ADDRESS:str:0x5FbDB2315678afecb367f032d93F642f64180aa3}
+        earliest_block_to_monitor: ${EARLIEST_BLOCK_TO_MONITOR:int:8053690}
+        history_end: null
+        ipfs_domain_name: /dns/registry.autonolas.tech/tcp/443/https
+        ipfs_gateway_base_url: ${IPFS_GATEWAY_BASE_URL:str:https://gateway.staging.autonolas.tech/ipfs/}
+        leaderboard_api_key: ${LEADERBOARD_API_KEY:str:<leaderboard_api_key>}
+        leaderboard_base_endpoint: ${LEADERBOARD_BASE_ENDPOINT:str:https://sheets.googleapis.com/v4/spreadsheets}
+        leaderboard_layers_range: ${LEADERBOARD_LAYERS_RANGE:str:Layers!B1:Z3}
+        leaderboard_points_range: ${LEADERBOARD_POINTS_RANGE:str:Ranking!B2:C302}
+        leaderboard_sheet_id: ${LEADERBOARD_SHEET_ID:str:1m7jUYBoK4bFF0F2ZRnT60wUCAMWGMJ_ZfALsLfW5Dxc}
+        reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
+        token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
+        share_tm_config_on_startup: ${USE_ACN:bool:false}
+        service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
+        on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
+        tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
+        tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
+        tendermint_p2p_url: ${TENDERMINT_P2P_URL_0:str:node0:26656}
+        setup:
+          all_participants: ${ALL_PARTICIPANTS:list:[]}
+          safe_contract_address: '0x0000000000000000000000000000000000000000'
+          consensus_threshold: null
+1:
+  models:
+    benchmark_tool:
+      args:
+        log_dir: /logs
+    params:
+      args:
+        broadcast_to_server: false
+        dynamic_contribution_contract_address: ${DYNAMIC_CONTRIBUTION_CONTRACT_ADDRESS:str:0x5FbDB2315678afecb367f032d93F642f64180aa3}
+        earliest_block_to_monitor: ${EARLIEST_BLOCK_TO_MONITOR:int:8053690}
+        history_end: null
+        ipfs_domain_name: /dns/registry.autonolas.tech/tcp/443/https
+        ipfs_gateway_base_url: ${IPFS_GATEWAY_BASE_URL:str:https://gateway.staging.autonolas.tech/ipfs/}
+        leaderboard_api_key: ${LEADERBOARD_API_KEY:str:<leaderboard_api_key>}
+        leaderboard_base_endpoint: ${LEADERBOARD_BASE_ENDPOINT:str:https://sheets.googleapis.com/v4/spreadsheets}
+        leaderboard_layers_range: ${LEADERBOARD_LAYERS_RANGE:str:Layers!B1:Z3}
+        leaderboard_points_range: ${LEADERBOARD_POINTS_RANGE:str:Ranking!B2:C302}
+        leaderboard_sheet_id: ${LEADERBOARD_SHEET_ID:str:1m7jUYBoK4bFF0F2ZRnT60wUCAMWGMJ_ZfALsLfW5Dxc}
+        reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
+        token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
+        share_tm_config_on_startup: ${USE_ACN:bool:false}
+        service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
+        on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
+        tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
+        tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
+        tendermint_p2p_url: ${TENDERMINT_P2P_URL_1:str:node1:26656}
+        setup:
+          all_participants: ${ALL_PARTICIPANTS:list:[]}
+          safe_contract_address: '0x0000000000000000000000000000000000000000'
+          consensus_threshold: null
+2:
+  models:
+    benchmark_tool:
+      args:
+        log_dir: /logs
+    params:
+      args:
+        broadcast_to_server: false
+        dynamic_contribution_contract_address: ${DYNAMIC_CONTRIBUTION_CONTRACT_ADDRESS:str:0x5FbDB2315678afecb367f032d93F642f64180aa3}
+        earliest_block_to_monitor: ${EARLIEST_BLOCK_TO_MONITOR:int:8053690}
+        history_end: null
+        ipfs_domain_name: /dns/registry.autonolas.tech/tcp/443/https
+        ipfs_gateway_base_url: ${IPFS_GATEWAY_BASE_URL:str:https://gateway.staging.autonolas.tech/ipfs/}
+        leaderboard_api_key: ${LEADERBOARD_API_KEY:str:<leaderboard_api_key>}
+        leaderboard_base_endpoint: ${LEADERBOARD_BASE_ENDPOINT:str:https://sheets.googleapis.com/v4/spreadsheets}
+        leaderboard_layers_range: ${LEADERBOARD_LAYERS_RANGE:str:Layers!B1:Z3}
+        leaderboard_points_range: ${LEADERBOARD_POINTS_RANGE:str:Ranking!B2:C302}
+        leaderboard_sheet_id: ${LEADERBOARD_SHEET_ID:str:1m7jUYBoK4bFF0F2ZRnT60wUCAMWGMJ_ZfALsLfW5Dxc}
+        reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
+        token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
+        share_tm_config_on_startup: ${USE_ACN:bool:false}
+        service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
+        on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
+        tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
+        tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
+        tendermint_p2p_url: ${TENDERMINT_P2P_URL_2:str:node2:26656}
+        setup:
+          all_participants: ${ALL_PARTICIPANTS:list:[]}
+          safe_contract_address: '0x0000000000000000000000000000000000000000'
+          consensus_threshold: null
+3:
+  models:
+    benchmark_tool:
+      args:
+        log_dir: /logs
+    params:
+      args:
+        broadcast_to_server: false
+        dynamic_contribution_contract_address: ${DYNAMIC_CONTRIBUTION_CONTRACT_ADDRESS:str:0x5FbDB2315678afecb367f032d93F642f64180aa3}
+        earliest_block_to_monitor: ${EARLIEST_BLOCK_TO_MONITOR:int:8053690}
+        history_end: null
+        ipfs_domain_name: /dns/registry.autonolas.tech/tcp/443/https
+        ipfs_gateway_base_url: ${IPFS_GATEWAY_BASE_URL:str:https://gateway.staging.autonolas.tech/ipfs/}
+        leaderboard_api_key: ${LEADERBOARD_API_KEY:str:<leaderboard_api_key>}
+        leaderboard_base_endpoint: ${LEADERBOARD_BASE_ENDPOINT:str:https://sheets.googleapis.com/v4/spreadsheets}
+        leaderboard_layers_range: ${LEADERBOARD_LAYERS_RANGE:str:Layers!B1:Z3}
+        leaderboard_points_range: ${LEADERBOARD_POINTS_RANGE:str:Ranking!B2:C302}
+        leaderboard_sheet_id: ${LEADERBOARD_SHEET_ID:str:1m7jUYBoK4bFF0F2ZRnT60wUCAMWGMJ_ZfALsLfW5Dxc}
+        reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
+        token_uri_base: ${TOKEN_URI_BASE:str:https://pfp.staging.autonolas.tech/}
+        share_tm_config_on_startup: ${USE_ACN:bool:false}
+        service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:null}
+        on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
+        tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
+        tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
+        tendermint_p2p_url: ${TENDERMINT_P2P_URL_3:str:node3:26656}
+        setup:
+          all_participants: ${ALL_PARTICIPANTS:list:[]}
+          safe_contract_address: '0x0000000000000000000000000000000000000000'
+          consensus_threshold: null
 ---
 public_id: valory/ledger:0.19.0
 type: connection

--- a/packages/valory/skills/contribution_abci/skill.yaml
+++ b/packages/valory/skills/contribution_abci/skill.yaml
@@ -23,10 +23,10 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeicn5utwviq46ubguok5rl5go4hb7oxluj7t6bja2ut4epjw2hevei
-- valory/dynamic_nft_abci:0.1.0:bafybeicvazrmiuf5k6n34hsif2esnm5c7m3afjzysprsa7jqxtfpwwf5vy
-- valory/registration_abci:0.1.0:bafybeid7gh35wnotm27hwuuuv3oozu33izjfafy7vbyzejdy3scx4oc7cu
-- valory/reset_pause_abci:0.1.0:bafybeidtb4v44zbxx7uw2c5yrbmmvzuh4mkgvcqdfyf4eq2xuhvxnbfiru
+- valory/abstract_round_abci:0.1.0:bafybeiacsn3k7q5ytxg52enceluqgp3xbzb4raks5vlkvmeikqje4fkes4
+- valory/dynamic_nft_abci:0.1.0:bafybeifo5gbu36ujrzap2b3iaejne2pewnjhxb4sdddumhjjagptkdnq4a
+- valory/registration_abci:0.1.0:bafybeicu26bx4er4z7d5ca6pxkagqu6u2zxajyzlknigde6sep4mblhq7q
+- valory/reset_pause_abci:0.1.0:bafybeigorzha2vv47yooay4tscn7qdu57e6lgudbacyiktnobmaw34j2pe
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/dynamic_nft_abci/skill.yaml
+++ b/packages/valory/skills/dynamic_nft_abci/skill.yaml
@@ -45,7 +45,7 @@ protocols:
 - valory/contract_api:1.0.0:bafybeidv6wxpjyb2sdyibnmmum45et4zcla6tl63bnol6ztyoqvpl4spmy
 - valory/http:1.0.0:bafybeifyoio7nlh5zzyn5yz7krkou56l22to3cwg7gw5v5o3vxwklibhty
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeicn5utwviq46ubguok5rl5go4hb7oxluj7t6bja2ut4epjw2hevei
+- valory/abstract_round_abci:0.1.0:bafybeiacsn3k7q5ytxg52enceluqgp3xbzb4raks5vlkvmeikqje4fkes4
 behaviours:
   main:
     args: {}

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ deps =
     open-aea-ledger-ethereum==1.31.0
     open-aea-ledger-cosmos==1.31.0
     open-aea-cli-ipfs==1.31.0
-    open-aea-test-autonomy==0.10.0.post1
-    open-autonomy==0.10.0.post1
+    open-aea-test-autonomy==0.10.0.post2
+    open-autonomy==0.10.0.post2
     Pillow==9.2.0
 setenv =
     PYTHONHASHSEED=0


### PR DESCRIPTION
Release `0.4.0.post1`

- Bump to `open-autonomy@v0.10.0.post2`
- Sets the `p2p_libp2p_client` as none abstract to enable `ACN`